### PR TITLE
647 Refactor pull-up sheets to use dynamic height

### DIFF
--- a/FRW/Modules/Browser/BrowserViewController.swift
+++ b/FRW/Modules/Browser/BrowserViewController.swift
@@ -261,7 +261,7 @@ extension BrowserViewController {
     @objc
     private func onMoveAssets() {
         if MoveAssetsAction.shared.allowMoveAssets {
-            let vc = PresentHostingController(rootView: MoveAssetsView())
+            let vc = makeAutoResizeSheetViewController(MoveAssetsView())
             navigationController?.present(vc, completion: nil)
         } else {
             HUD.info(title: "Features Coming Soon")

--- a/FRW/Modules/Browser/View/BrowserAuthnView.swift
+++ b/FRW/Modules/Browser/View/BrowserAuthnView.swift
@@ -11,7 +11,9 @@ import SwiftUI
 
 // MARK: - BrowserAuthnView
 
-struct BrowserAuthnView: View {
+struct BrowserAuthnView: View, PresentActionDelegate {
+    var changeHeight: (() -> Void)?
+    
     // MARK: Lifecycle
 
     init(vm: BrowserAuthnViewModel) {

--- a/FRW/Modules/Browser/View/BrowserAuthzView.swift
+++ b/FRW/Modules/Browser/View/BrowserAuthzView.swift
@@ -11,7 +11,9 @@ import SwiftUI
 
 // MARK: - BrowserAuthzView
 
-struct BrowserAuthzView: View {
+struct BrowserAuthzView: View, PresentActionDelegate {
+    var changeHeight: (() -> Void)?
+    
     // MARK: Lifecycle
 
     init(vm: BrowserAuthzViewModel) {

--- a/FRW/Modules/Browser/View/BrowserSignMessageView.swift
+++ b/FRW/Modules/Browser/View/BrowserSignMessageView.swift
@@ -10,7 +10,9 @@ import SwiftUI
 
 // MARK: - BrowserSignMessageView
 
-struct BrowserSignMessageView: View {
+struct BrowserSignMessageView: View, PresentActionDelegate {
+    var changeHeight: (() -> Void)?
+    
     // MARK: Lifecycle
 
     init(vm: BrowserSignMessageViewModel) {
@@ -25,6 +27,8 @@ struct BrowserSignMessageView: View {
 
     var body: some View {
         normalView
+            .fixedSize(horizontal: false, vertical: true)
+            .ignoresSafeArea()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.ultraThickMaterial)
     }

--- a/FRW/Modules/Browser/View/BrowserSignTypedMessageView.swift
+++ b/FRW/Modules/Browser/View/BrowserSignTypedMessageView.swift
@@ -10,7 +10,9 @@ import SwiftUI
 
 // MARK: - BrowserSignTypedMessageView
 
-struct BrowserSignTypedMessageView: View {
+struct BrowserSignTypedMessageView: View, PresentActionDelegate {
+    var changeHeight: (() -> Void)?
+    
     // MARK: Lifecycle
 
     init(viewModel: BrowserSignTypedMessageViewModel) {

--- a/FRW/Modules/Browser/View/NetworkSwitchPopView.swift
+++ b/FRW/Modules/Browser/View/NetworkSwitchPopView.swift
@@ -103,6 +103,8 @@ struct NetworkSwitchPopView: View {
                 .padding(.horizontal, 16)
                 .padding(.bottom, 20)
         }
+        .fixedSize(horizontal: false, vertical: true)
+        .ignoresSafeArea()
         .backgroundFill(Color.LL.Neutrals.background)
     }
 

--- a/FRW/Modules/ChildAccount/ChildAccountLinkView.swift
+++ b/FRW/Modules/ChildAccount/ChildAccountLinkView.swift
@@ -48,6 +48,8 @@ struct ChildAccountLinkView: View {
             .padding(.horizontal, 18)
             .padding(.bottom, 20)
         }
+        .fixedSize(horizontal: false, vertical: true)
+        .ignoresSafeArea()
         .backgroundFill(Color.LL.Neutrals.background)
     }
 

--- a/FRW/Modules/JailbreakAlert/JailbreakAlertView.swift
+++ b/FRW/Modules/JailbreakAlert/JailbreakAlertView.swift
@@ -27,6 +27,8 @@ struct JailbreakAlertView: View {
                 .padding(.horizontal, 18)
                 .padding(.bottom, 20)
         }
+        .fixedSize(horizontal: false, vertical: true)
+        .ignoresSafeArea()
         .backgroundFill(Color.LL.Neutrals.background)
     }
 

--- a/FRW/Modules/Login/SyncAddDeviceView.swift
+++ b/FRW/Modules/Login/SyncAddDeviceView.swift
@@ -85,6 +85,8 @@ struct SyncAddDeviceView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 20)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .fixedSize(horizontal: false, vertical: true)
+        .ignoresSafeArea()
         .backgroundFill(Color(hex: "#282828", alpha: 1))
     }
 

--- a/FRW/Modules/MultiBackup/View/BackupListView.swift
+++ b/FRW/Modules/MultiBackup/View/BackupListView.swift
@@ -65,7 +65,7 @@ struct BackupListView: RouteableView {
         }
         .applyRouteable(self)
         .backgroundFill(Color.LL.Neutrals.background)
-        .halfSheet(showSheet: $viewModel.showRemoveTipView, autoResizing: true, backgroundColor: Color.LL.Neutrals.background) {
+        .halfSheet(showSheet: $viewModel.showRemoveTipView, backgroundColor: Color.LL.Neutrals.background) {
             DangerousTipSheetView(
                 title: "account_key_revoke_title".localized,
                 detail: "account_key_revoke_content".localized,

--- a/FRW/Modules/MultiBackup/View/MultiBackupDetailView.swift
+++ b/FRW/Modules/MultiBackup/View/MultiBackupDetailView.swift
@@ -82,7 +82,7 @@ struct MultiBackupDetailView: RouteableView {
             .padding(.horizontal, 18)
         }
         .applyRouteable(self)
-        .halfSheet(showSheet: $viewModel.showRemoveTipView, autoResizing: true, backgroundColor: Color.LL.Neutrals.background) {
+        .halfSheet(showSheet: $viewModel.showRemoveTipView, backgroundColor: Color.LL.Neutrals.background) {
             DangerousTipSheetView(
                 title: "account_key_revoke_title".localized,
                 detail: "account_key_revoke_content".localized,

--- a/FRW/Modules/NFT/NFTDetailPage.swift
+++ b/FRW/Modules/NFT/NFTDetailPage.swift
@@ -341,7 +341,7 @@ struct NFTDetailPage: RouteableView {
                     }
                 }
             }
-            .halfSheet(showSheet: $vm.isPresentMove, autoResizing: true, backgroundColor: Color.Theme.Background.grey) {
+            .halfSheet(showSheet: $vm.isPresentMove, backgroundColor: Color.Theme.Background.grey) {
                 MoveSingleNFTView(nft: vm.nft, fromChildAccount: fromChildAccount) {
                     withAnimation {
                         DispatchQueue.main.async {

--- a/FRW/Modules/NFT/Views/NFTAddCollectionView.swift
+++ b/FRW/Modules/NFT/Views/NFTAddCollectionView.swift
@@ -50,15 +50,18 @@ struct NFTAddCollectionView: RouteableView {
         }
         .background(Color.LL.Neutrals.background)
         .applyRouteable(self)
-        .halfSheet(showSheet: $addViewModel.isConfirmSheetPresented, autoResizing: true, backgroundColor: Color.LL.Neutrals.background) {
-            if let item = self.selectItem {
-                NFTAddCollectionView.NFTCollectionEnableView(item: item)
-                    .environmentObject(addViewModel)
-            }
-        }
+        .halfSheet(showSheet: $addViewModel.isConfirmSheetPresented, backgroundColor: Color.LL.Neutrals.background, sheetViewBuilder: sheetViewBuilder)
         .mockPlaceholder(addViewModel.isMock)
     }
 
+    @ViewBuilder
+    private func sheetViewBuilder() -> some View {
+        if let item = self.selectItem {
+            NFTAddCollectionView.NFTCollectionEnableView(item: item)
+                .environmentObject(addViewModel)
+        }
+    }
+    
     private func title(title: String) -> some View {
         Text(title.localized.uppercased())
             .foregroundColor(.LL.Neutrals.neutrals6)

--- a/FRW/Modules/Profile/AccountSetting/ChildAccountDetailView.swift
+++ b/FRW/Modules/Profile/AccountSetting/ChildAccountDetailView.swift
@@ -285,7 +285,7 @@ struct ChildAccountDetailView: RouteableView {
         .padding(.bottom, 20)
         .backgroundFill(Color.LL.Neutrals.background)
         .applyRouteable(self)
-        .halfSheet(showSheet: $vm.isPresent, autoResizing: true, backgroundColor: Color.LL.Neutrals.background) {
+        .halfSheet(showSheet: $vm.isPresent, backgroundColor: Color.LL.Neutrals.background) {
             UnlinkConfirmView()
                 .environmentObject(vm)
         }

--- a/FRW/Modules/Profile/Devices/DevicesInfoView.swift
+++ b/FRW/Modules/Profile/Devices/DevicesInfoView.swift
@@ -119,7 +119,7 @@ struct DevicesInfoView: RouteableView {
             .visibility(viewModel.showRevokeButton ? .visible : .gone)
         }
         .applyRouteable(self)
-        .halfSheet(showSheet: $viewModel.showRemoveTipView, autoResizing: true, backgroundColor: Color.LL.Neutrals.background) {
+        .halfSheet(showSheet: $viewModel.showRemoveTipView, backgroundColor: Color.LL.Neutrals.background) {
             DangerousTipSheetView(
                 title: "account_key_revoke_title".localized,
                 detail: "account_key_revoke_content".localized,

--- a/FRW/Modules/Profile/WalletSetting/AccountKeys.swift
+++ b/FRW/Modules/Profile/WalletSetting/AccountKeys.swift
@@ -28,7 +28,7 @@ struct AccountKeysView: RouteableView {
         }
         .backgroundFill(.Theme.Background.white)
         .mockPlaceholder(vm.status == PageStatus.loading)
-        .halfSheet(showSheet: $vm.showRovekeView, autoResizing: true, backgroundColor: Color.LL.Neutrals.background) {
+        .halfSheet(showSheet: $vm.showRovekeView, backgroundColor: Color.LL.Neutrals.background) {
             AccountKeyRevokeView()
                 .environmentObject(vm)
         }

--- a/FRW/Modules/Staking/StakeAmount/StakeAmountView.swift
+++ b/FRW/Modules/Staking/StakeAmount/StakeAmountView.swift
@@ -48,7 +48,7 @@ struct StakeAmountView: RouteableView {
         .padding(.top, 12)
         .padding(.bottom, 20)
         .backgroundFill(.LL.deepBg)
-        .halfSheet(showSheet: $vm.showConfirmView, autoResizing: true, backgroundColor: Color.LL.deepBg, sheetView: {
+        .halfSheet(showSheet: $vm.showConfirmView, backgroundColor: Color.LL.deepBg, sheetViewBuilder: {
             StakeConfirmView()
                 .environmentObject(vm)
         })

--- a/FRW/Modules/Staking/StakeAmount/StakeAmountView.swift
+++ b/FRW/Modules/Staking/StakeAmount/StakeAmountView.swift
@@ -409,6 +409,8 @@ extension StakeAmountView {
                 .padding(.horizontal, 18)
                 .padding(.bottom, 20)
             }
+            .fixedSize(horizontal: false, vertical: true)
+            .ignoresSafeArea()
             .backgroundFill(Color.LL.deepBg)
         }
 

--- a/FRW/Modules/Swap/SwapView.swift
+++ b/FRW/Modules/Swap/SwapView.swift
@@ -58,7 +58,7 @@ struct SwapView: RouteableView {
         .frame(maxWidth: .infinity)
         .background(Color.LL.background)
         .applyRouteable(self)
-        .halfSheet(showSheet: $vm.showConfirmView, autoResizing: true, backgroundColor: Color.LL.background) {
+        .halfSheet(showSheet: $vm.showConfirmView, backgroundColor: Color.LL.background) {
             SwapConfirmView()
                 .environmentObject(vm)
         }

--- a/FRW/Modules/Wallet/AddToken/AddTokenView.swift
+++ b/FRW/Modules/Wallet/AddToken/AddTokenView.swift
@@ -36,17 +36,20 @@ struct AddTokenView: RouteableView {
         }
     }
 
+    @ViewBuilder
+    private func sheetViewBuilder() -> some View {
+        if let token = vm.pendingActiveToken {
+            AddTokenConfirmView(token: token)
+                .environmentObject(vm)
+        }
+    }
+    
     var body: some View {
         ZStack {
             listView
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .halfSheet(showSheet: $vm.confirmSheetIsPresented, autoResizing: true, backgroundColor: Color.LL.Neutrals.background, sheetView: {
-            if let token = vm.pendingActiveToken {
-                AddTokenConfirmView(token: token)
-                    .environmentObject(vm)
-            }
-        })
+        .halfSheet(showSheet: $vm.confirmSheetIsPresented, backgroundColor: Color.LL.Neutrals.background, sheetViewBuilder: sheetViewBuilder)
         .environmentObject(vm)
         .disabled(vm.isRequesting)
         .applyRouteable(self)

--- a/FRW/Modules/Wallet/MoveAsset/MoveAssetsView.swift
+++ b/FRW/Modules/Wallet/MoveAsset/MoveAssetsView.swift
@@ -8,16 +8,11 @@
 import SwiftUI
 import SwiftUIX
 
-struct MoveAssetsView: RouteableView, PresentActionDelegate {
+struct MoveAssetsView: RouteableView {
     // MARK: Internal
 
-    var changeHeight: (() -> Void)?
-
     var token: TokenModel?
-
-    var title: String {
-        ""
-    }
+    var title: String { "" }
 
     var showCheck: Bool {
         MoveAssetsAction.shared.showCheckOnMoveAsset
@@ -31,92 +26,90 @@ struct MoveAssetsView: RouteableView, PresentActionDelegate {
     }
 
     var body: some View {
-        ScrollView {
-            VStack {
-                TitleWithClosedView(title: "move_assets".localized, closeAction: {
-                    Router.dismiss(animated: true, completion: {
-                        MoveAssetsAction.shared.endBrowser()
-                    })
+        VStack {
+            TitleWithClosedView(title: "move_assets".localized, closeAction: {
+                Router.dismiss(animated: true, completion: {
+                    MoveAssetsAction.shared.endBrowser()
                 })
+            })
+            .padding(.top, 24)
+
+            Text(showNote)
+                .font(.inter(size: 14))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(Color.Theme.Text.black8)
+                .frame(height: 72)
+
+            HStack {
+                Button {
+                    onClose()
+                    Router.route(to: RouteMap.Wallet.moveNFTs)
+                } label: {
+                    card(isNFT: true)
+                }
+                .buttonStyle(ScaleButtonStyle())
+
+                Spacer()
+                Button {
+                    if let current = currentToken() {
+                        onClose()
+                        Router.route(to: RouteMap.Wallet.moveToken(current))
+                    } else {
+                        HUD.error(title: "not found token")
+                    }
+                } label: {
+                    card(isNFT: false)
+                }
+                .buttonStyle(ScaleButtonStyle())
+            }
+            .padding(.top, 32)
+
+            if showCheck {
+                VPrimaryButton(
+                    model: ButtonStyle.primary,
+                    state: .enabled,
+                    action: {
+                        Router.dismiss(animated: true, completion: {
+                            MoveAssetsAction.shared.endBrowser()
+                        })
+                    },
+                    title: "skip".localized
+                )
                 .padding(.top, 24)
 
-                Text(showNote)
-                    .font(.inter(size: 14))
-                    .multilineTextAlignment(.center)
-                    .foregroundStyle(Color.Theme.Text.black8)
-                    .frame(height: 72)
-
                 HStack {
-                    Button {
-                        onClose()
-                        Router.route(to: RouteMap.Wallet.moveNFTs)
-                    } label: {
-                        card(isNFT: true)
-                    }
-                    .buttonStyle(ScaleButtonStyle())
-
                     Spacer()
-                    Button {
-                        if let current = currentToken() {
-                            onClose()
-                            Router.route(to: RouteMap.Wallet.moveToken(current))
-                        } else {
-                            HUD.error(title: "not found token")
-                        }
-                    } label: {
-                        card(isNFT: false)
-                    }
-                    .buttonStyle(ScaleButtonStyle())
-                }
-                .padding(.top, 32)
-
-                if showCheck {
-                    VPrimaryButton(
-                        model: ButtonStyle.primary,
-                        state: .enabled,
-                        action: {
-                            Router.dismiss(animated: true, completion: {
-                                MoveAssetsAction.shared.endBrowser()
-                            })
-                        },
-                        title: "skip".localized
-                    )
-                    .padding(.top, 24)
-
-                    HStack {
-                        Spacer()
-                        if notAsk {
-                            Image("icon_check_rounde_0")
-                                .resizable()
-                                .renderingMode(.template)
-                                .foregroundStyle(Color.Theme.Text.black8)
-                                .frame(width: 16, height: 16)
-                        } else {
-                            Image("icon_check_rounde_1")
-                                .resizable()
-                                .frame(width: 16, height: 16)
-                        }
-
-                        Text("do_not_ask".localized)
-                            .font(.inter(size: 16))
+                    if notAsk {
+                        Image("icon_check_rounde_0")
+                            .resizable()
+                            .renderingMode(.template)
                             .foregroundStyle(Color.Theme.Text.black8)
-                        Spacer()
+                            .frame(width: 16, height: 16)
+                    } else {
+                        Image("icon_check_rounde_1")
+                            .resizable()
+                            .frame(width: 16, height: 16)
                     }
-                    .padding(.top)
-                    .onTapGesture {
-                        notAsk.toggle()
-                    }
-                    .padding(.bottom, 43)
-                } else {
+
+                    Text("do_not_ask".localized)
+                        .font(.inter(size: 16))
+                        .foregroundStyle(Color.Theme.Text.black8)
                     Spacer()
                 }
+                .padding(.top)
+                .onTapGesture {
+                    notAsk.toggle()
+                }
+                .padding(.bottom, 43)
+            } else {
+                Spacer()
             }
-            .padding(.horizontal, 18)
         }
-        .backgroundFill(Color.Theme.Background.grey)
+        .padding(.horizontal, 18)
         .cornerRadius([.topLeading, .topTrailing], 16)
         .applyRouteable(self)
         .edgesIgnoringSafeArea(.all)
+        .backgroundFill(Color.Theme.Background.grey)
     }
 
     func toName() -> String {

--- a/FRW/Modules/Wallet/Send/WalletSendAmountView.swift
+++ b/FRW/Modules/Wallet/Send/WalletSendAmountView.swift
@@ -58,7 +58,7 @@ struct WalletSendAmountView: RouteableView {
 //        .interactiveDismissDisabled()
         .buttonStyle(.plain)
         .backgroundFill(Color.LL.background)
-        .halfSheet(showSheet: $vm.showConfirmView, autoResizing: true, backgroundColor: Color.LL.Neutrals.background, sheetView: {
+        .halfSheet(showSheet: $vm.showConfirmView, backgroundColor: Color.LL.Neutrals.background, sheetViewBuilder: {
             SendConfirmView()
                 .environmentObject(vm)
         })

--- a/FRW/Modules/Wallet/TokenDetail/TokenDetailView.swift
+++ b/FRW/Modules/Wallet/TokenDetail/TokenDetailView.swift
@@ -74,11 +74,7 @@ struct TokenDetailView: RouteableView {
         .buttonStyle(.plain)
         .backgroundFill(.LL.deepBg)
         .applyRouteable(self)
-        .halfSheet(showSheet: $vm.showSheet, autoResizing: true, backgroundColor: Color.Theme.BG.bg1) {
-            if vm.buttonAction == .move {
-                MoveTokenView(tokenModel: vm.token, isPresent: $vm.showSheet)
-            }
-        }
+        .halfSheet(showSheet: $vm.showSheet, backgroundColor: Color.Theme.BG.bg1, sheetViewBuilder: sheetViewBuilder)
         .navigationBarItems(trailing: HStack(spacing: 6) {
             Menu(systemImage: "ellipsis") {
                 Button("Delete EFT", systemImage: "trash") {
@@ -90,6 +86,13 @@ struct TokenDetailView: RouteableView {
         })
     }
 
+    @ViewBuilder
+    private func sheetViewBuilder() -> some View {
+        if vm.buttonAction == .move {
+            MoveTokenView(tokenModel: vm.token, isPresent: $vm.showSheet)
+        }
+    }
+    
     var summaryView: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {

--- a/FRW/Modules/Wallet/WalletHomeView.swift
+++ b/FRW/Modules/Wallet/WalletHomeView.swift
@@ -71,7 +71,7 @@ struct WalletHomeView: View {
                 GuestView().visibility(um.isLoggedIn ? .gone : .visible)
                 NormalView().visibility(um.isLoggedIn ? .visible : .gone)
             }
-            .halfSheet(showSheet: $vm.backupTipsPresent, autoResizing: true, backgroundColor: Color.LL.Neutrals.background) {
+            .halfSheet(showSheet: $vm.backupTipsPresent, backgroundColor: Color.LL.Neutrals.background) {
                 BackupTipsView(closeAction: {
                     vm.backupTipsPresent = false
                 })

--- a/FRW/Services/Router/RouteMap.swift
+++ b/FRW/Services/Router/RouteMap.swift
@@ -66,7 +66,7 @@ extension RouteMap.RestoreLogin: RouterTarget {
         case let .syncAccount(info):
             navi.push(content: SyncConfirmView(user: info))
         case let .syncDevice(vm):
-            let vc = CustomHostingController(rootView: SyncAddDeviceView(viewModel: vm))
+            let vc = makeAutoResizeSheetViewController(SyncAddDeviceView(viewModel: vm))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case .restoreList:
             navi.push(content: RestoreListView())
@@ -263,7 +263,7 @@ extension RouteMap.Wallet: RouterTarget {
 //            let rootVC = Router.topPresentedController()
             SPQRCode.scanning(handled: handler, click: click, on: navi)
         case .buyCrypto:
-            let vc = CustomHostingController(rootView: BuyProvderView())
+            let vc = makeAutoResizeSheetViewController(BuyProvderView())
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case let .transactionList(contractId):
             let vc = TransactionListViewController(contractId: contractId)
@@ -289,7 +289,7 @@ extension RouteMap.Wallet: RouterTarget {
         case let .stakeDetail(provider, node):
             navi.push(content: StakingDetailView(provider: provider, node: node))
         case let .stakeSetupConfirm(vm):
-            let vc = CustomHostingController(rootView: StakeAmountView.StakeSetupView(vm: vm))
+            let vc = makeAutoResizeSheetViewController(StakeAmountView.StakeSetupView(vm: vm))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case .backToTokenDetail:
             if let existVC = navi.viewControllers
@@ -300,7 +300,7 @@ extension RouteMap.Wallet: RouterTarget {
 
             navi.popToRootViewController(animated: true)
         case .jailbreakAlert:
-            let vc = CustomHostingController(rootView: JailbreakAlertView())
+            let vc = makeAutoResizeSheetViewController(JailbreakAlertView())
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case .pushAlert:
             let vc = RouteableUIHostingController(rootView: PushAlertView())
@@ -580,7 +580,7 @@ extension RouteMap.NFT: RouterTarget {
         case .addCollection:
             navi.push(content: NFTAddCollectionView())
         case let .send(nft, contact, childAccount):
-            let vc = CustomHostingController(rootView: NFTTransferView(
+            let vc = makeAutoResizeSheetViewController(NFTTransferView(
                 nft: nft,
                 target: contact,
                 fromChildAccount: childAccount
@@ -657,16 +657,13 @@ extension RouteMap.Explore: RouterTarget {
             let vc = SFSafariViewController(url: url)
             navi.present(vc, animated: true)
         case let .authn(vm):
-            let vc = CustomHostingController(rootView: BrowserAuthnView(vm: vm))
+            let vc = makeAutoResizeSheetViewController(BrowserAuthnView(vm: vm))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case let .authz(vm):
-            let vc = CustomHostingController(rootView: BrowserAuthzView(vm: vm), showLarge: true)
+            let vc = makeAutoResizeSheetViewController(BrowserAuthzView(vm: vm))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case let .signMessage(vm):
-            let vc = CustomHostingController(
-                rootView: BrowserSignMessageView(vm: vm),
-                showLarge: true
-            )
+            let vc = makeAutoResizeSheetViewController(BrowserSignMessageView(vm: vm))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case .searchExplore:
             let inputVC = BrowserSearchInputViewController()
@@ -686,18 +683,15 @@ extension RouteMap.Explore: RouterTarget {
         case .bookmark:
             navi.present(content: BrowserBookmarkView())
         case let .linkChildAccount(vm):
-            let vc = CustomHostingController(rootView: ChildAccountLinkView(vm: vm))
+            let vc = makeAutoResizeSheetViewController(ChildAccountLinkView(vm: vm))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case .dapps:
             navi.present(content: DAppsListView())
         case let .switchNetwork(from, to, callback):
-            let vc = CustomHostingController(rootView: NetworkSwitchPopView(from: from, to: to))
+            let vc = makeAutoResizeSheetViewController(NetworkSwitchPopView(from: from, to: to))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case let .signTypedMessage(viewModel):
-            let vc = CustomHostingController(
-                rootView: BrowserSignTypedMessageView(viewModel: viewModel),
-                showLarge: true
-            )
+            let vc = makeAutoResizeSheetViewController(BrowserSignTypedMessageView(viewModel: viewModel))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         }
     }

--- a/FRW/Services/Router/RouteMap.swift
+++ b/FRW/Services/Router/RouteMap.swift
@@ -317,10 +317,10 @@ extension RouteMap.Wallet: RouterTarget {
             let vc = PresentHostingController(rootView: MoveNFTsView())
             navi.present(vc, animated: true, completion: nil)
         case .moveAssets:
-            let vc = PresentHostingController(rootView: MoveAssetsView())
+            let vc = makeAutoResizeSheetViewController(MoveAssetsView())
             navi.present(vc, animated: true, completion: nil)
         case let .moveToken(tokenModel):
-            let vc = PresentHostingController(rootView: MoveTokenView(
+            let vc = makeAutoResizeSheetViewController(MoveTokenView(
                 tokenModel: tokenModel,
                 isPresent: .constant(true)
             ))
@@ -340,12 +340,7 @@ extension RouteMap.Wallet: RouterTarget {
         case let .showCustomToken(token):
             navi.push(content: CustomTokenDetailView(token: token))
         case let .addTokenSheet(token, callback):
-            let vc = PresentHostingController(
-                rootView: AddTokenSheetView(
-                    customToken: token,
-                    callback: callback
-                )
-            )
+            let vc = PresentHostingController(rootView: AddTokenSheetView(customToken: token, callback: callback))
             navi.present(vc, completion: nil)
         }
     }
@@ -657,13 +652,13 @@ extension RouteMap.Explore: RouterTarget {
             let vc = SFSafariViewController(url: url)
             navi.present(vc, animated: true)
         case let .authn(vm):
-            let vc = makeAutoResizeSheetViewController(BrowserAuthnView(vm: vm))
+            let vc = PresentHostingController(rootView: BrowserAuthnView(vm: vm))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case let .authz(vm):
-            let vc = makeAutoResizeSheetViewController(BrowserAuthzView(vm: vm))
+            let vc = PresentHostingController(rootView: BrowserAuthzView(vm: vm))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case let .signMessage(vm):
-            let vc = makeAutoResizeSheetViewController(BrowserSignMessageView(vm: vm))
+            let vc = PresentHostingController(rootView: BrowserSignMessageView(vm: vm))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case .searchExplore:
             let inputVC = BrowserSearchInputViewController()
@@ -687,11 +682,11 @@ extension RouteMap.Explore: RouterTarget {
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case .dapps:
             navi.present(content: DAppsListView())
-        case let .switchNetwork(from, to, callback):
+        case let .switchNetwork(from, to, _):
             let vc = makeAutoResizeSheetViewController(NetworkSwitchPopView(from: from, to: to))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         case let .signTypedMessage(viewModel):
-            let vc = makeAutoResizeSheetViewController(BrowserSignTypedMessageView(viewModel: viewModel))
+            let vc = PresentHostingController(rootView: BrowserSignTypedMessageView(viewModel: viewModel))
             Router.topPresentedController().present(vc, animated: true, completion: nil)
         }
     }

--- a/FRW/UI/Component/HalfSheetModal.swift
+++ b/FRW/UI/Component/HalfSheetModal.swift
@@ -181,7 +181,7 @@ func makeAutoResizeSheetViewController<Container: View>(_ view: Container) -> UI
 // MARK: - CustomHostingController
 
 // Custom UIHostingController for halfSheet....
-final class CustomHostingController<Content: View>: UIHostingController<SheetContainerView<Content>> {
+private final class CustomHostingController<Content: View>: UIHostingController<SheetContainerView<Content>> {
     // MARK: Lifecycle
     private let viewModel = SheetContainerViewModel()
     


### PR DESCRIPTION
## Related Issue

https://github.com/Outblock/FRW-iOS/issues/647

## Summary of Changes

Refactored the implementation of the half-sheet so that its height was dynamically set depending on the content.
This solution doesn't work with views having scroll views (even when combined with a geometry reader) because of the intrinsic size. These views will use the existing `PresentHostingController` with a fixed-sized sheet that can expand from half to full height.

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [x] Yes
- [ ] No

All views (listed below) should be checked to verify the correct layout.

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [x] Medium
- [ ] High

## Additional Notes

Views migrated to use the dynamic pull-up sheet (in `RouteMap` unless otherwise specified):

- `MoveAssetsView` in `BrowserViewController`
- `SyncAddDeviceView`
- `BuyProvderView`
- `StakeAmountView.StakeSetupView`
- `JailbreakAlertView`
- `MoveAssetsView`
- `MoveTokenView`
- `NFTTransferView`
- `ChildAccountLinkView`
- `NetworkSwitchPopView`

Views automatically using the dynamic pull-up sheet (without any refactoring on a per-view basis):

- `AccountKeysView` showing `AccountKeyRevokeView`
- `AddTokenView` showing `AddTokenConfirmView`
- `BackupListView` showing `DangerousTipSheetView`
- `ChildAccountDetailView` showing `UnlinkConfirmView`
- `DevicesInfoView` showing `DangerousTipSheetView`
- `MultiBackupDetailView` showing `DangerousTipSheetView`
- `NFTAddCollectionView` showing `NFTAddCollectionView.NFTCollectionEnableView`
- `NFTDetailPage` showing `MoveSingleNFTView`
- `StakeAmountView` showing `StakeConfirmView`
- `SwapView` showing `SwapConfirmView`
- `TokenDetailView` showing `MoveTokenView`
- `WalletHomeView` showing `BackupTipsView`
- `WalletSendAmountView` showing `SendConfirmView`

Views using the old `PresentHostingController` (in `RouteMap`):

- `ImportAccountsView`
- `MoveNFTsView`
- `MoveAccountsView`
- `AddTokenSheetView`
- `AccountSwitchView`
- `BrowserAuthnView`
- `BrowserAuthzView`
- `BrowserSignMessageView`
- `BrowserSignTypedMessageView`


## Screenshots (if applicable)
 N/A
