### PR TITLE
788 misc priority fixes

### DIFF
--- a/FRW/Modules/Explore/ExploreTabScreen.swift
+++ b/FRW/Modules/Explore/ExploreTabScreen.swift
@@ -140,26 +140,10 @@ struct ExploreTabScreen: View {
             Image(systemName: "square.grid.2x2.fill")
                 .font(.LL.caption)
             Text("dApps".localized)
-                .bold()
+                .font(.LL.largeTitle2)
+                .semibold()
             Spacer()
 
-            Button {
-                Router.route(to: RouteMap.Explore.dapps)
-            } label: {
-                HStack(spacing: 5) {
-                    Text("browser_bookmark_view".localized)
-                        .font(.inter(size: 16, weight: .medium))
-                        .foregroundColor(Color(hex: "#7D7AFF"))
-
-                    Image("icon-search-arrow")
-                        .renderingMode(.template)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 15, height: 11)
-                        .foregroundColor(Color(hex: "#C2C3F2"))
-                }
-                .contentShape(Rectangle())
-            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/FRW/Modules/MultiBackup/View/IntroductionView.swift
+++ b/FRW/Modules/MultiBackup/View/IntroductionView.swift
@@ -69,7 +69,7 @@ extension IntroductionView {
         var titleTop: String {
             switch self {
             case .whatMultiBackup:
-                return "What is a".localized
+                return "what_is".localized
             case .aboutRecoveryPhrase:
                 return "about_phrase_title_top".localized
             }

--- a/FRW/Modules/NFT/UIKit/NFTUIKitListViewController.swift
+++ b/FRW/Modules/NFT/UIKit/NFTUIKitListViewController.swift
@@ -141,30 +141,6 @@ class NFTUIKitListViewController: UIViewController {
         return view
     }()
 
-    private lazy var segmentControl: NFTUIKitSegmentControl = {
-        let view = NFTUIKitSegmentControl(names: ["seg_list".localized, "seg_grid".localized])
-        view.callback = { [weak self] index in
-            guard let self = self else {
-                return
-            }
-
-            switch index {
-            case 0:
-                self.style = .normal
-            case 1:
-                self.style = .grid
-            default:
-                break
-            }
-
-            let feedbackGenerator = UIImpactFeedbackGenerator(style: .rigid)
-            feedbackGenerator.impactOccurred()
-
-            self.reloadViews()
-        }
-        return view
-    }()
-
     private lazy var addButton: UIButton = {
         let btn = UIButton(type: .custom)
         btn.setImage(UIImage(named: "icon-nft-add"), for: .normal)
@@ -258,12 +234,6 @@ class NFTUIKitListViewController: UIViewController {
         headerContainerView.addSubview(headerContentView)
         headerContentView.snp.makeConstraints { make in
             make.left.right.bottom.equalToSuperview()
-        }
-
-        headerContentView.addSubview(segmentControl)
-        segmentControl.snp.makeConstraints { make in
-            make.left.equalTo(18)
-            make.centerY.equalToSuperview()
         }
 
         headerContentView.addSubview(addButton)

--- a/FRW/Modules/Profile/ProfileView.swift
+++ b/FRW/Modules/Profile/ProfileView.swift
@@ -112,30 +112,30 @@ extension ProfileView {
 
         var body: some View {
             Section {
-                HStack {
-                    VStack {
-                        Image("icon-cool-cat")
-                    }.frame(maxHeight: .infinity, alignment: .top)
-
-                    VStack(alignment: .leading) {
-                        Text(title).font(.inter(size: 16, weight: .bold))
-                        Text(desc).font(.inter(size: 16))
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    Button {
-                        Router.route(to: RouteMap.Register.root(nil))
-                    } label: {
+                Button {
+                    Router.route(to: RouteMap.Register.root(nil))
+                } label: {
+                    HStack {
+                        VStack {
+                            Image("icon-cool-cat")
+                        }.frame(maxHeight: .infinity, alignment: .top)
+                        
+                        VStack(alignment: .leading) {
+                            Text(title).font(.inter(size: 16, weight: .bold))
+                            Text(desc).font(.inter(size: 16))
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        
                         Image("icon-orange-right-arrow")
                     }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 16)
+                    .roundedBg(
+                        cornerRadius: 12,
+                        strokeColor: .LL.Primary.salmonPrimary,
+                        strokeLineWidth: 1
+                    )
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 16)
-                .roundedBg(
-                    cornerRadius: 12,
-                    strokeColor: .LL.Primary.salmonPrimary,
-                    strokeLineWidth: 1
-                )
             }
             .listRowInsets(.zero)
             .listRowBackground(Color.clear)

--- a/FRW/Modules/Wallet/CreateAccount/CreateProfileWaitingView.swift
+++ b/FRW/Modules/Wallet/CreateAccount/CreateProfileWaitingView.swift
@@ -93,20 +93,6 @@ struct CreateProfileWaitingView: RouteableView {
                             .background(Color.Theme.Accent.green)
                             .cornerRadius(16)
                         }
-                        
-                        Button {
-                            viewModel.onGoHome()
-                        } label: {
-                            HStack {
-                                Text("maybe_later_text".localized)
-                                    .font(.inter(size: 14, weight: .bold))
-                                    .foregroundStyle(Color.Theme.Text.black8)
-                            }
-                            .padding(.vertical, 16)
-                            .frame(maxWidth: .infinity)
-                            .background(Color.Theme.Background.grey)
-                            .cornerRadius(16)
-                        }
                     }
                     .padding(.horizontal, 16)
                 } else {

--- a/FRW/Modules/Wallet/Send/WalletSendView.swift
+++ b/FRW/Modules/Wallet/Send/WalletSendView.swift
@@ -69,6 +69,17 @@ struct WalletSendView: RouteableView {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: 0) {
                     Button {
+                        vm.changeTabTypeAction(type: .accounts)
+                    } label: {
+                        SwitchButton(
+                            icon: "profile-tab",
+                            title: "my_accounts".localized,
+                            isSelected: vm.tabType == .accounts
+                        )
+                        .contentShape(Rectangle())
+                    }
+
+                    Button {
                         vm.changeTabTypeAction(type: .recent)
                     } label: {
                         SwitchButton(
@@ -86,17 +97,6 @@ struct WalletSendView: RouteableView {
                             icon: "icon-addressbook",
                             title: "address_book".localized,
                             isSelected: vm.tabType == .addressBook
-                        )
-                        .contentShape(Rectangle())
-                    }
-
-                    Button {
-                        vm.changeTabTypeAction(type: .accounts)
-                    } label: {
-                        SwitchButton(
-                            icon: "profile-tab",
-                            title: "my_accounts".localized,
-                            isSelected: vm.tabType == .accounts
                         )
                         .contentShape(Rectangle())
                     }

--- a/FRW/Modules/Wallet/Send/WalletSendViewModel.swift
+++ b/FRW/Modules/Wallet/Send/WalletSendViewModel.swift
@@ -15,9 +15,9 @@ import Combine
 
 extension WalletSendView {
     enum TabType: Int, CaseIterable {
+        case accounts
         case recent
         case addressBook
-        case accounts
     }
 
     enum ViewStatus {
@@ -137,7 +137,7 @@ class WalletSendViewModel: ObservableObject {
     var errorType: WalletSendView.ErrorType = .none
 
     @Published
-    var tabType: WalletSendView.TabType = .recent
+    var tabType: WalletSendView.TabType = .accounts
     @Published
     var searchText: String = ""
     @Published

--- a/FRW/Modules/Wallet/WalletHomeView.swift
+++ b/FRW/Modules/Wallet/WalletHomeView.swift
@@ -178,19 +178,6 @@ struct WalletHomeView: View {
 
                 HStack {
                     Button {
-                        vm.moveAssetsAction()
-                    } label: {
-                        Image("icon_wallet_home_move")
-                            .resizable()
-                            .renderingMode(.template)
-                            .aspectRatio(contentMode: .fit)
-                            .foregroundStyle(Color.Theme.Text.black8)
-                            .frame(width: 24, height: 24)
-                            .padding(8)
-                    }
-                    .visibility(vm.showMoveAsset ? .visible : .gone)
-
-                    Button {
                         Router.route(to: RouteMap.Wallet.transactionList(nil))
                     } label: {
                         Image("icon_wallet_home_time")

--- a/FRW/Resource/Assets.xcassets/backup/questionmark.circle.imageset/Contents.json
+++ b/FRW/Resource/Assets.xcassets/backup/questionmark.circle.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "Question Mark cr-fr.svg",
+      "filename" : "questionmark.circle.svg",
       "idiom" : "universal"
     },
     {
@@ -11,7 +11,7 @@
           "value" : "dark"
         }
       ],
-      "filename" : "questionmark.circle.svg",
+      "filename" : "Question Mark cr-fr.svg",
       "idiom" : "universal"
     }
   ],

--- a/FRW/Resource/en.lproj/Localizable.strings
+++ b/FRW/Resource/en.lproj/Localizable.strings
@@ -744,7 +744,7 @@
 "stake_flow" = "Stake Flow";
 "stake_guide_text_1" = "When You";
 "stake_guide_text_2" = "Stake Your Flow";
-"stake_guide_btn_text" = "Let's Staking";
+"stake_guide_btn_text" = "Let's Stake";
 "stake_on_lilico_only" = "On Flow Wallet Only";
 "stake_guide_desc_1_1" = "Earn up to ";
 "stake_guide_desc_1_2" = "9%";
@@ -761,7 +761,7 @@
 "stake_guide_desc_3_2" = "next epoch";
 "stake_guide_desc_3_3" = ".";
 "stake_guide_desc_4_1" = "Rewards are automatically credited to your\n";
-"stake_guide_desc_4_2" = "deposit";
+"stake_guide_desc_4_2" = "deposit ";
 "stake_guide_desc_4_3" = "every week";
 "stake_guide_desc_4_4" = ".";
 "stake_amount" = "Stake Amount";

--- a/FRW/Services/Router/RouteMap.swift
+++ b/FRW/Services/Router/RouteMap.swift
@@ -296,6 +296,9 @@ extension RouteMap.Wallet: RouterTarget {
             navi.present(content: AddTokenView(vm: vm))
         case .stakingList:
             navi.push(content: StakingListView())
+            if StakingManager.shared.isStaked == false {
+                Router.route(to: RouteMap.Wallet.stakingSelectProvider)
+            }
         case .stakingSelectProvider:
             navi.push(content: SelectProviderView())
         case .stakeGuide:


### PR DESCRIPTION
## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->
https://github.com/Outblock/FRW-iOS/issues/788

## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->
-remove extra List/Grid toggle.
- Remove the “view” tab on top Fix the “Apps” title to be the same height as the title on the collections page.	
- fix localization fix backwards light/dark mode for help icon	
- In send, it should default to open the “My accounts” tab and have it as the left-most item.	
- Stake button on the dashboard should open the “Node providers list” directly, not show an empty staking list if the user has not already staked
- remove "Maybe Later" to force backing up keys.	
- Strings tweaks Make whole "Welcome" cell tappable.	
- Remove "Move Assets" button from home screen

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [ ] Yes
- [x] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [x] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
