### PR TITLE
[FEATURE] Add an alert when user tries to back out of the backup flow #791

### DIFF
--- a/FRW/Modules/MultiBackup/ViewModel/BackupListViewModel.swift
+++ b/FRW/Modules/MultiBackup/ViewModel/BackupListViewModel.swift
@@ -198,6 +198,13 @@ extension BackupListViewModel {
     var hasPhraseBackup: Bool {
         !phraseList.isEmpty
     }
+    
+    var hasSomeBackup: Bool {
+        //TODO: MU: this one isn't working properly, it reports device backups even if there is none.
+//        hasDeviceBackup ||
+        hasMultiBackup ||
+        hasPhraseBackup
+    }
 }
 
 extension BackupListViewModel {

--- a/FRW/Resource/en.lproj/Localizable.strings
+++ b/FRW/Resource/en.lproj/Localizable.strings
@@ -1126,3 +1126,7 @@ Key Store and Private Key.";
 "Covered by Flow Wallet" = "Covered by Flow Wallet";
 "Contact Address" = "Contact Address";
 "Choose Swap Provider" = "Choose Swap Provider";
+"no_backup_warning_title" = "Are you sure you don't want to make a backup?";
+"no_backup_warning_desc" = "If you lose your device or delete your wallet, your funds will be lost forever.";
+"im_sure" = "I'm sure";
+"make_backup" = "Make backup";

--- a/FRW/UI/Component/AlertView/AlertView.swift
+++ b/FRW/UI/Component/AlertView/AlertView.swift
@@ -17,6 +17,7 @@ extension AlertView {
         case confirm
         case primaryAction
         case secondaryAction
+        case destructive
 
         // MARK: Internal
 
@@ -30,6 +31,8 @@ extension AlertView {
                 return Color.LL.Button.Primary.text
             case .secondaryAction:
                 return Color.LL.Button.Elevated.text
+            case .destructive:
+                return Color.LL.Button.Primary.text
             }
         }
 
@@ -43,6 +46,8 @@ extension AlertView {
                 return Color.Theme.Accent.green
             case .secondaryAction:
                 return Color.LL.Button.Elevated.Secondary.background
+            case .destructive:
+                return Color.LL.error
             }
         }
 
@@ -333,7 +338,7 @@ final class AlertViewController: UIHostingController<AlertViewController.AlertCo
             EmptyView()
                 .background(Color.clear)
                 .customAlertView(
-                    isPresented: self.isPresented,
+                    isPresented: isPresented,
                     title: title,
                     customContentView: customContentView,
                     buttons: buttons,


### PR DESCRIPTION

## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->
https://github.com/Outblock/FRW-iOS/issues/791

## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->
Show an confirmation alert if the user tries to back out of the Backup creation flow without creating a backup.

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [ ] Yes
- [x] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [x] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
