### PR TITLE
feat: #595 Default Token for "Send" Button Should Be FLOW

### DIFF
--- a/FRW/Modules/Wallet/WalletHomeView.swift
+++ b/FRW/Modules/Wallet/WalletHomeView.swift
@@ -448,6 +448,7 @@ struct WalletHomeView: View {
                 event: .send,
                 allowClick: !wm.isSelectedChildAccount
             ) {
+                LocalUserDefaults.shared.recentToken = nil
                 Router.route(to: RouteMap.Wallet.send())
             }
 


### PR DESCRIPTION
## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->

Closes #595

## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->

Default Token for "Send" Button Should Be FLOW
when click the "send" button on Home, set nil for `LocalUserDefaults.shared.recentToken`

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [x] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [x] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
