### PR TITLE
Origin/907 feature display fractional cent usd prices values in the correct format

### DIFF
--- a/FRW/Modules/Inbox/InboxView.swift
+++ b/FRW/Modules/Inbox/InboxView.swift
@@ -139,7 +139,7 @@ extension InboxView {
                     Spacer()
 
                     Text(
-                        "\(CurrencyCache.cache.currencySymbol)\(item.marketPrice.formatCurrencyString(considerCustomCurrency: true))"
+                        "\(CurrencyCache.cache.currencySymbol)\(item.marketPrice.formatCurrencyStringForDisplay(considerCustomCurrency: true))"
                     )
                     .font(.inter(size: 16, weight: .medium))
                     .foregroundColor(Color.LL.Neutrals.text)

--- a/FRW/Modules/Staking/Model/StakingProvider.swift
+++ b/FRW/Modules/Staking/Model/StakingProvider.swift
@@ -28,7 +28,7 @@ struct StakingProvider: Codable {
     }
 
     var apyYearPercentString: String {
-        let num = (rate * 100).formatCurrencyString(digits: 2)
+        let num = (rate * 100).formatCurrencyStringForDisplay(digits: 2)
         return "\(num)%"
     }
 

--- a/FRW/Modules/Staking/Model/StakingProvider.swift
+++ b/FRW/Modules/Staking/Model/StakingProvider.swift
@@ -28,7 +28,7 @@ struct StakingProvider: Codable {
     }
 
     var apyYearPercentString: String {
-        let num = (rate * 100).formatCurrencyString()
+        let num = (rate * 100).formatCurrencyString(digits: 2)
         return "\(num)%"
     }
 

--- a/FRW/Modules/Staking/StakeAmount/StakeAmountView.swift
+++ b/FRW/Modules/Staking/StakeAmount/StakeAmountView.swift
@@ -96,7 +96,7 @@ struct StakeAmountView: RouteableView {
                     .frame(width: 12, height: 12)
 
                 Text(
-                    "\(vm.balance.formatCurrencyString()) \(vm.isUnstake ? "staked_flow".localized : "stake_flow_available".localized)"
+                    "\(vm.balance.formatCurrencyStringForDisplay()) \(vm.isUnstake ? "staked_flow".localized : "stake_flow_available".localized)"
                 )
                 .font(.inter(size: 14, weight: .medium))
                 .foregroundColor(Color.LL.Neutrals.text2)
@@ -300,7 +300,7 @@ extension StakeAmountView {
                     .background(Color.LL.Neutrals.note)
 
                 HStack(spacing: 0) {
-                    Text(vm.inputTextNum.formatCurrencyString())
+                    Text(vm.inputTextNum.formatCurrencyStringForDisplay())
                         .font(.inter(size: 24, weight: .bold))
                         .foregroundColor(Color.LL.Neutrals.text)
 

--- a/FRW/Modules/Staking/StakeAmount/StakeAmountViewModel.swift
+++ b/FRW/Modules/Staking/StakeAmount/StakeAmountViewModel.swift
@@ -85,11 +85,11 @@ class StakeAmountViewModel: ObservableObject {
     }
 
     var inputNumAsCurrencyString: String {
-        "\(CurrencyCache.cache.currencySymbol)\(inputNumAsUSD.formatCurrencyString(considerCustomCurrency: true)) \(CurrencyCache.cache.currentCurrency.rawValue)"
+        "\(CurrencyCache.cache.currencySymbol)\(inputNumAsUSD.formatCurrencyStringForDisplay(considerCustomCurrency: true)) \(CurrencyCache.cache.currentCurrency.rawValue)"
     }
 
     var inputNumAsCurrencyStringInConfirmSheet: String {
-        "\(CurrencyCache.cache.currencySymbol)\(inputNumAsUSD.formatCurrencyString(considerCustomCurrency: true))"
+        "\(CurrencyCache.cache.currencySymbol)\(inputNumAsUSD.formatCurrencyStringForDisplay(considerCustomCurrency: true))"
     }
 
     var yearReward: Double {
@@ -97,12 +97,12 @@ class StakeAmountViewModel: ObservableObject {
     }
 
     var yearRewardFlowString: String {
-        yearReward.formatCurrencyString()
+        yearReward.formatCurrencyStringForDisplay()
     }
 
     var yearRewardWithCurrencyString: String {
         let numString = (inputNumAsUSD * provider.rate)
-            .formatCurrencyString(considerCustomCurrency: true)
+            .formatCurrencyStringForDisplay(considerCustomCurrency: true)
         return "\(CurrencyCache.cache.currencySymbol)\(numString) \(CurrencyCache.cache.currentCurrency.rawValue)"
     }
 
@@ -140,7 +140,7 @@ extension StakeAmountViewModel {
     }
 
     func percentAction(percent: Double) {
-        inputText = "\((balance * percent).formatCurrencyString())"
+        inputText = "\((balance * percent).formatCurrencyStringForTransaction())"
     }
 
     func confirmSetupAction() {

--- a/FRW/Modules/Staking/StakingDetail/StakingDetailView.swift
+++ b/FRW/Modules/Staking/StakingDetail/StakingDetailView.swift
@@ -109,7 +109,7 @@ struct StakingDetailView: RouteableView {
 
             HStack(alignment: .bottom, spacing: 0) {
                 Text(
-                    "\(CurrencyCache.cache.currencySymbol)\(vm.node.tokenStakedASUSD.formatCurrencyString(digits: 3, considerCustomCurrency: true))"
+                    "\(CurrencyCache.cache.currencySymbol)\(vm.node.tokenStakedASUSD.formatCurrencyStringForDisplay(digits: 3, considerCustomCurrency: true))"
                 )
                 .font(.inter(size: 32, weight: .semibold))
                 .foregroundColor(Color.LL.Neutrals.text)
@@ -128,7 +128,7 @@ struct StakingDetailView: RouteableView {
                     .resizable()
                     .frame(width: 16, height: 16)
 
-                Text(vm.node.tokensStaked.formatCurrencyString(digits: 3))
+                Text(vm.node.tokensStaked.formatCurrencyStringForDisplay(digits: 3))
                     .font(.inter(size: 14, weight: .semibold))
                     .foregroundColor(Color.LL.Neutrals.text)
 
@@ -140,7 +140,7 @@ struct StakingDetailView: RouteableView {
                     .frame(width: 1, height: 12)
                     .background(Color.LL.Neutrals.note)
 
-                Text("\(vm.availableAmount.formatCurrencyString(digits: 3))")
+                Text("\(vm.availableAmount.formatCurrencyStringForDisplay(digits: 3))")
                     .font(.inter(size: 14, weight: .semibold))
                     .foregroundColor(Color.LL.Neutrals.text)
 
@@ -159,7 +159,7 @@ struct StakingDetailView: RouteableView {
                     .padding(.bottom, 4)
 
                 HStack(spacing: 0) {
-                    Text("\(vm.node.tokensRewarded.formatCurrencyString(digits: 3))")
+                    Text("\(vm.node.tokensRewarded.formatCurrencyStringForDisplay(digits: 3))")
                         .font(.inter(size: 24, weight: .semibold))
                         .foregroundColor(Color.LL.Neutrals.text)
 
@@ -277,7 +277,7 @@ struct StakingDetailView: RouteableView {
             }
 
             HStack(spacing: 0) {
-                Text("\(vm.node.tokensUnstaked.formatCurrencyString(digits: 3))")
+                Text("\(vm.node.tokensUnstaked.formatCurrencyStringForDisplay(digits: 3))")
                     .font(.inter(size: 24, weight: .semibold))
                     .foregroundColor(Color.LL.Neutrals.text)
 
@@ -327,7 +327,7 @@ struct StakingDetailView: RouteableView {
 
                 Spacer()
 
-                Text("+\(vm.node.tokensCommitted.formatCurrencyString(digits: 3))")
+                Text("+\(vm.node.tokensCommitted.formatCurrencyStringForDisplay(digits: 3))")
                     .font(.inter(size: 20, weight: .medium))
                     .foregroundColor(Color.LL.Neutrals.text)
 
@@ -366,7 +366,7 @@ struct StakingDetailView: RouteableView {
 
                 Spacer()
 
-                Text("-\(vm.node.tokensRequestedToUnstake.formatCurrencyString(digits: 3))")
+                Text("-\(vm.node.tokensRequestedToUnstake.formatCurrencyStringForDisplay(digits: 3))")
                     .font(.inter(size: 20, weight: .medium))
                     .foregroundColor(Color.LL.Neutrals.text)
 
@@ -404,7 +404,7 @@ struct StakingDetailView: RouteableView {
 
                 Spacer()
 
-                Text("-\(vm.node.tokensUnstaking.formatCurrencyString(digits: 3))")
+                Text("-\(vm.node.tokensUnstaking.formatCurrencyStringForDisplay(digits: 3))")
                     .font(.inter(size: 20, weight: .medium))
                     .foregroundColor(Color.LL.Neutrals.text)
 
@@ -443,7 +443,7 @@ struct StakingDetailView: RouteableView {
 
                 HStack(alignment: .bottom, spacing: 5) {
                     Text(
-                        "\(CurrencyCache.cache.currentCurrency.symbol)\(vm.node.dayRewardsASUSD.formatCurrencyString(digits: 3, considerCustomCurrency: true))"
+                        "\(CurrencyCache.cache.currentCurrency.symbol)\(vm.node.dayRewardsASUSD.formatCurrencyStringForDisplay(digits: 3, considerCustomCurrency: true))"
                     )
                     .font(.inter(size: 24, weight: .bold))
                     .foregroundColor(Color.LL.Neutrals.text)
@@ -454,7 +454,7 @@ struct StakingDetailView: RouteableView {
                         .padding(.bottom, 5)
                 }
 
-                Text("\(vm.node.dayRewards.formatCurrencyString(digits: 3)) Flow")
+                Text("\(vm.node.dayRewards.formatCurrencyStringForDisplay(digits: 3)) Flow")
                     .font(.inter(size: 12, weight: .semibold))
                     .foregroundColor(Color.LL.Neutrals.text3)
             }
@@ -471,7 +471,7 @@ struct StakingDetailView: RouteableView {
 
                 HStack(alignment: .bottom, spacing: 5) {
                     Text(
-                        "\(CurrencyCache.cache.currentCurrency.symbol)\(vm.node.monthRewardsASUSD.formatCurrencyString(digits: 3, considerCustomCurrency: true))"
+                        "\(CurrencyCache.cache.currentCurrency.symbol)\(vm.node.monthRewardsASUSD.formatCurrencyStringForDisplay(digits: 3, considerCustomCurrency: true))"
                     )
                     .font(.inter(size: 24, weight: .bold))
                     .foregroundColor(Color.LL.Neutrals.text)
@@ -482,7 +482,7 @@ struct StakingDetailView: RouteableView {
                         .padding(.bottom, 5)
                 }
 
-                Text("\(vm.node.monthRewards.formatCurrencyString(digits: 3)) Flow")
+                Text("\(vm.node.monthRewards.formatCurrencyStringForDisplay(digits: 3)) Flow")
                     .font(.inter(size: 12, weight: .semibold))
                     .foregroundColor(Color.LL.Neutrals.text3)
             }
@@ -497,27 +497,27 @@ struct StakingDetailView: RouteableView {
         VStack(spacing: 0) {
             createListCell(
                 key: "stake_unstaked_amount".localized,
-                value: "\(vm.node.tokensUnstaked.formatCurrencyString(digits: 3)) Flow"
+                value: "\(vm.node.tokensUnstaked.formatCurrencyStringForDisplay(digits: 3)) Flow"
             )
             Divider().foregroundColor(Color.LL.Neutrals.text2)
             createListCell(
                 key: "stake_unstaking_amount".localized,
-                value: "\(vm.node.tokensUnstaking.formatCurrencyString(digits: 3)) Flow"
+                value: "\(vm.node.tokensUnstaking.formatCurrencyStringForDisplay(digits: 3)) Flow"
             )
             Divider().foregroundColor(Color.LL.Neutrals.text2)
             createListCell(
                 key: "stake_committed_amount".localized,
-                value: "\(vm.node.tokensCommitted.formatCurrencyString(digits: 3)) Flow"
+                value: "\(vm.node.tokensCommitted.formatCurrencyStringForDisplay(digits: 3)) Flow"
             )
             Divider().foregroundColor(Color.LL.Neutrals.text2)
             createListCell(
                 key: "stake_requested_to_unstake_amount".localized,
-                value: "\(vm.node.tokensRequestedToUnstake.formatCurrencyString(digits: 3)) Flow"
+                value: "\(vm.node.tokensRequestedToUnstake.formatCurrencyStringForDisplay(digits: 3)) Flow"
             )
             Divider().foregroundColor(Color.LL.Neutrals.text2)
             createListCell(
                 key: "stake_apr".localized,
-                value: "\((vm.provider.rate * 100).formatCurrencyString(digits: 2)) %"
+                value: "\((vm.provider.rate * 100).formatCurrencyStringForDisplay(digits: 2)) %"
             )
         }
         .padding(.horizontal, 18)

--- a/FRW/Modules/Staking/StakingDetail/StakingDetailView.swift
+++ b/FRW/Modules/Staking/StakingDetail/StakingDetailView.swift
@@ -517,7 +517,7 @@ struct StakingDetailView: RouteableView {
             Divider().foregroundColor(Color.LL.Neutrals.text2)
             createListCell(
                 key: "stake_apr".localized,
-                value: "\((vm.provider.rate * 100).formatCurrencyString()) %"
+                value: "\((vm.provider.rate * 100).formatCurrencyString(digits: 2)) %"
             )
         }
         .padding(.horizontal, 18)

--- a/FRW/Modules/Staking/StakingListView.swift
+++ b/FRW/Modules/Staking/StakingListView.swift
@@ -236,7 +236,7 @@ struct StakingListView: RouteableView {
         ]
 
         let numStr = NSMutableAttributedString(
-            string: "\(num.formatCurrencyString(digits: 3)) ",
+            string: "\(num.formatCurrencyStringForDisplay(digits: 3)) ",
             attributes: boldAttrs
         )
         let normalStr = NSAttributedString(string: "Flow", attributes: normalAttrs)

--- a/FRW/Modules/Swap/SwapConfirmView.swift
+++ b/FRW/Modules/Swap/SwapConfirmView.swift
@@ -99,7 +99,7 @@ struct SwapConfirmView: View {
 
                 Text(
                     ((vm.estimateResponse?.priceImpact ?? 0.0) * -100)
-                        .formatCurrencyString(digits: 4) + "%"
+                        .formatCurrencyStringForDisplay(digits: 4) + "%"
                 )
                 .font(.inter(size: 14, weight: .medium))
                 .foregroundColor(Color.LL.Success.success1)
@@ -114,7 +114,7 @@ struct SwapConfirmView: View {
 //
 //                Spacer()
 //
-//                Text(vm.estimateResponse?.priceImpact.formatCurrencyString(digits: 4) ?? "0")
+//                Text(vm.estimateResponse?.priceImpact.formatCurrencyStringForDisplay(digits: 4) ?? "0")
 //                    .font(.inter(size: 14, weight: .medium))
 //                    .foregroundColor(Color.LL.Neutrals.text)
 //                    .lineLimit(1)

--- a/FRW/Modules/Swap/SwapViewModel.swift
+++ b/FRW/Modules/Swap/SwapViewModel.swift
@@ -100,7 +100,7 @@ class SwapViewModel: ObservableObject {
             return ""
         }
 
-        return "1 \(fromToken.symbol?.uppercased() ?? "") ≈ \((amountOut / amountIn).formatCurrencyString()) \(toToken.symbol?.uppercased() ?? "")"
+        return "1 \(fromToken.symbol?.uppercased() ?? "") ≈ \((amountOut / amountIn).formatCurrencyStringForDisplay()) \(toToken.symbol?.uppercased() ?? "")"
     }
 
     var fromAmount: Double {
@@ -124,7 +124,7 @@ class SwapViewModel: ObservableObject {
     }
 
     var fromPriceAmountString: String {
-        (fromAmount * fromTokenRate).formatCurrencyString(considerCustomCurrency: true)
+        (fromAmount * fromTokenRate).formatCurrencyStringForDisplay(considerCustomCurrency: true)
     }
 
     // MARK: Private
@@ -199,11 +199,11 @@ extension SwapViewModel {
                     }
 
                     if localIsFromInput {
-                        self.oldInputToText = "\(response.tokenOutAmount.formatCurrencyString())"
-                        self.inputToText = "\(response.tokenOutAmount.formatCurrencyString())"
+                        self.oldInputToText = "\(response.tokenOutAmount.formatCurrencyStringForTransaction())"
+                        self.inputToText = "\(response.tokenOutAmount.formatCurrencyStringForTransaction())"
                     } else {
-                        self.oldInputFromText = "\(response.tokenInAmount.formatCurrencyString())"
-                        self.inputFromText = "\(response.tokenInAmount.formatCurrencyString())"
+                        self.oldInputFromText = "\(response.tokenInAmount.formatCurrencyStringForTransaction())"
+                        self.inputFromText = "\(response.tokenInAmount.formatCurrencyStringForTransaction())"
                     }
 
                     self.estimateResponse = response
@@ -356,7 +356,7 @@ extension SwapViewModel {
 
         inputFromText = WalletManager.shared
             .getBalance(byId: contractId).doubleValue
-            .formatCurrencyString()
+            .formatCurrencyStringForTransaction()
     }
 
     func swapAction() {

--- a/FRW/Modules/TransactionList/Model/FlowScanTransfer.swift
+++ b/FRW/Modules/TransactionList/Model/FlowScanTransfer.swift
@@ -36,11 +36,13 @@ struct FlowScanTransfer: Codable {
     let type: Int?
     let contractAddress: String?
 
+
     private var isSealed: Bool {
         status?.lowercased() == "Sealed".lowercased() || status?.lowercased() == "success"
     }
 
     var statusColor: UIColor {
+
         guard isSealed else {
             return UIColor.LL.Neutrals.text3
         }
@@ -97,8 +99,8 @@ struct FlowScanTransfer: Codable {
     }
 
     var amountString: String {
-        if let amountString = amount, !amountString.isEmpty {
-            return amountString
+        if let amountString = amount, !amountString.isEmpty, let formattedString = Double(amountString)?.formatCurrencyStringForDisplay(digits: 4) {
+            return formattedString
         } else {
             return "-"
         }

--- a/FRW/Modules/Wallet/MoveAsset/ViewModel/MoveTokenViewModel.swift
+++ b/FRW/Modules/Wallet/MoveAsset/ViewModel/MoveTokenViewModel.swift
@@ -103,7 +103,7 @@ final class MoveTokenViewModel: ObservableObject {
     }
 
     var currentBalance: String {
-        let totalStr = amountBalance.doubleValue.formatCurrencyString()
+        let totalStr = amountBalance.doubleValue.formatCurrencyStringForDisplay()
         return "\(totalStr)"
     }
 
@@ -195,7 +195,7 @@ final class MoveTokenViewModel: ObservableObject {
         Task {
             let num = await updateAmountIfNeed(inputAmount: amountBalance)
             await MainActor.run {
-                self.showBalance = num.doubleValue.formatCurrencyString()
+                self.showBalance = num.doubleValue.formatCurrencyStringForDisplay()
                 self.actualBalance = num
                 self.refreshSummary()
                 self.updateState()
@@ -409,7 +409,7 @@ extension MoveTokenViewModel {
     }
 
     var balanceAsCurrentCurrencyString: String {
-        inputDollarNum.formatCurrencyString(considerCustomCurrency: true)
+        inputDollarNum.formatCurrencyStringForDisplay(considerCustomCurrency: true)
     }
 
     var showFee: Bool {

--- a/FRW/Modules/Wallet/Send/WalletSendAmountView.swift
+++ b/FRW/Modules/Wallet/Send/WalletSendAmountView.swift
@@ -233,8 +233,8 @@ struct WalletSendAmountView: RouteableView {
                         .visibility(vm.exchangeType == .dollar ? .visible : .gone)
 
                     Text(
-                        vm.exchangeType == .token ? vm.inputDollarNum.formatCurrencyString() : vm
-                            .inputTokenNum.formatCurrencyString()
+                        vm.exchangeType == .token ? vm.inputDollarNum.formatCurrencyStringForDisplay() : vm
+                            .inputTokenNum.formatCurrencyStringForDisplay()
                     )
                     .foregroundColor(.LL.Neutrals.note)
                     .font(.inter(size: 16, weight: .medium))
@@ -341,13 +341,13 @@ struct WalletSendAmountView: RouteableView {
                     .clipShape(Circle())
 
                 Text(
-                    "\(vm.amountBalance.formatCurrencyString()) \(vm.token.symbol?.uppercased() ?? "?")"
+                    "\(vm.amountBalance.formatCurrencyStringForDisplay()) \(vm.token.symbol?.uppercased() ?? "?")"
                 )
                 .foregroundColor(.LL.Neutrals.text)
                 .font(.inter(size: 14, weight: .medium))
 
                 Text(
-                    "≈ \(CurrencyCache.cache.currencySymbol) \(vm.amountBalanceAsDollar.formatCurrencyString(considerCustomCurrency: true))"
+                    "≈ \(CurrencyCache.cache.currencySymbol) \(vm.amountBalanceAsDollar.formatCurrencyStringForDisplay(considerCustomCurrency: true))"
                 )
                 .foregroundColor(.LL.Neutrals.text)
                 .font(.inter(size: 14, weight: .medium))
@@ -495,9 +495,11 @@ extension WalletSendAmountView {
                 HStack {
                     Spacer()
 
-                    Text("\(CurrencyCache.cache.currentCurrency.rawValue) \(CurrencyCache.cache.currencySymbol) \(vm.inputDollarNum.formatCurrencyString())")
-                        .foregroundColor(.LL.Neutrals.neutrals8)
-                        .font(.inter(size: 14, weight: .medium))
+                    Text(
+                        "\(CurrencyCache.cache.currentCurrency.rawValue) \(CurrencyCache.cache.currencySymbol) \(vm.inputDollarNum.formatCurrencyStringForDisplay())"
+                    )
+                    .foregroundColor(.LL.Neutrals.neutrals8)
+                    .font(.inter(size: 14, weight: .medium))
                 }
                 .padding(.top, 14)
             }

--- a/FRW/Modules/Wallet/Send/WalletSendAmountViewModel.swift
+++ b/FRW/Modules/Wallet/Send/WalletSendAmountViewModel.swift
@@ -268,7 +268,7 @@ extension WalletSendAmountViewModel: InsufficientStorageToastViewModel {
 
 extension WalletSendAmountViewModel {
     func inputTextDidChangeAction(text _: String) {
-        actualBalance = inputText.doubleValue.formatCurrencyString(digits: token.decimal)
+        actualBalance = inputText.doubleValue.formatCurrencyStringForTransaction(digits: token.decimal)
         refreshInput()
     }
 
@@ -285,37 +285,37 @@ extension WalletSendAmountViewModel {
                         0
                     )
                     DispatchQueue.main.async {
-                        self.inputText = num.formatCurrencyString()
+                        self.inputText = num.formatCurrencyStringForTransaction()
                     }
 
-                    actualBalance = num.formatCurrencyString(digits: token.decimal)
+                    actualBalance = num.formatCurrencyStringForTransaction(digits: token.decimal)
                 } catch {
                     let num = max(amountBalance - minBalance.doubleValue, 0)
                     DispatchQueue.main.async {
-                        self.inputText = num.formatCurrencyString()
+                        self.inputText = num.formatCurrencyStringForTransaction()
                     }
-                    actualBalance = num.formatCurrencyString(digits: token.decimal)
+                    actualBalance = num.formatCurrencyStringForTransaction(digits: token.decimal)
                     log.error("[Flow] min flow balance error")
                 }
             }
         } else {
             let num = max(amountBalance, 0)
-            inputText = num.formatCurrencyString()
-            actualBalance = num.formatCurrencyString(digits: token.decimal)
+            inputText = num.formatCurrencyStringForTransaction()
+            actualBalance = num.formatCurrencyStringForTransaction(digits: token.decimal)
         }
     }
 
     func toggleExchangeTypeAction() {
         if exchangeType == .token, coinRate != 0 {
             exchangeType = .dollar
-            inputText = inputDollarNum.formatCurrencyString()
+            inputText = inputDollarNum.formatCurrencyStringForTransaction()
             actualBalance = inputDollarNum
-                .formatCurrencyString(digits: token.decimal)
+                .formatCurrencyStringForTransaction(digits: token.decimal)
         } else {
             exchangeType = .token
-            inputText = inputTokenNum.formatCurrencyString()
+            inputText = inputTokenNum.formatCurrencyStringForTransaction()
             actualBalance = inputTokenNum
-                .formatCurrencyString(digits: token.decimal)
+                .formatCurrencyStringForTransaction(digits: token.decimal)
         }
     }
 

--- a/FRW/Modules/Wallet/TokenDetail/TokenDetailView.swift
+++ b/FRW/Modules/Wallet/TokenDetail/TokenDetailView.swift
@@ -246,7 +246,7 @@ struct TokenDetailView: RouteableView {
 
                     HStack(spacing: 4) {
                         Text(
-                            "\(CurrencyCache.cache.currencySymbol)\(vm.rate.formatCurrencyString(considerCustomCurrency: true))"
+                            "\(CurrencyCache.cache.currencySymbol)\(vm.rate.formatCurrencyStringForDisplay(considerCustomCurrency: true))"
                         )
                         .foregroundColor(.LL.Neutrals.text)
                         .font(.inter(size: 14, weight: .regular))
@@ -615,7 +615,7 @@ extension TokenDetailView {
 
                     HStack(spacing: 10) {
                         Text(
-                            "\(stakingManager.stakingCount.formatCurrencyString()) \(vm.token.symbol?.uppercased() ?? "?")"
+                            "\(stakingManager.stakingCount.formatCurrencyStringForDisplay()) \(vm.token.symbol?.uppercased() ?? "?")"
                         )
                         .font(.inter(size: 14))
                         .foregroundColor(Color.LL.Neutrals.text)
@@ -638,13 +638,13 @@ extension TokenDetailView {
                             .foregroundColor(Color.LL.Neutrals.text)
 
                         Text(
-                            "\(CurrencyCache.cache.currentCurrency.symbol)\(stakingManager.dayRewardsASUSD.formatCurrencyString(considerCustomCurrency: true))"
+                            "\(CurrencyCache.cache.currentCurrency.symbol)\(stakingManager.dayRewardsASUSD.formatCurrencyStringForDisplay(considerCustomCurrency: true))"
                         )
                         .font(.inter(size: 24, weight: .bold))
                         .foregroundColor(Color.LL.Neutrals.text)
 
                         Text(
-                            "\(stakingManager.dayRewards.formatCurrencyString()) \(vm.token.symbol?.uppercased() ?? "?")"
+                            "\(stakingManager.dayRewards.formatCurrencyStringForDisplay()) \(vm.token.symbol?.uppercased() ?? "?")"
                         )
                         .font(.inter(size: 12, weight: .semibold))
                         .foregroundColor(Color.LL.Neutrals.text3)
@@ -661,13 +661,13 @@ extension TokenDetailView {
                             .foregroundColor(Color.LL.Neutrals.text)
 
                         Text(
-                            "\(CurrencyCache.cache.currentCurrency.symbol)\(stakingManager.monthRewardsASUSD.formatCurrencyString(considerCustomCurrency: true))"
+                            "\(CurrencyCache.cache.currentCurrency.symbol)\(stakingManager.monthRewardsASUSD.formatCurrencyStringForDisplay(considerCustomCurrency: true))"
                         )
                         .font(.inter(size: 24, weight: .bold))
                         .foregroundColor(Color.LL.Neutrals.text)
 
                         Text(
-                            "\(stakingManager.monthRewards.formatCurrencyString()) \(vm.token.symbol?.uppercased() ?? "?")"
+                            "\(stakingManager.monthRewards.formatCurrencyStringForDisplay()) \(vm.token.symbol?.uppercased() ?? "?")"
                         )
                         .font(.inter(size: 12, weight: .semibold))
                         .foregroundColor(Color.LL.Neutrals.text3)

--- a/FRW/Modules/Wallet/TokenDetail/TokenDetailViewModel.swift
+++ b/FRW/Modules/Wallet/TokenDetail/TokenDetailViewModel.swift
@@ -22,7 +22,7 @@ extension TokenDetailView {
 
         var generateChartPoint: LineChartDataPoint {
             let date = Date(timeIntervalSince1970: closeTime)
-            let price = Double(closePrice.formatCurrencyString(
+            let price = Double(closePrice.formatCurrencyStringForTransaction(
                 digits: 2,
                 considerCustomCurrency: true
             )) ?? 0
@@ -215,11 +215,11 @@ extension TokenDetailViewModel {
     }
 
     var balanceString: String {
-        balance.formatCurrencyString()
+        balance.formatCurrencyStringForDisplay()
     }
 
     var balanceAsCurrentCurrencyString: String {
-        balanceAsUSD.formatCurrencyString(considerCustomCurrency: true)
+        balanceAsUSD.formatCurrencyStringForDisplay(considerCustomCurrency: true)
     }
 
     var changeIsNegative: Bool {

--- a/FRW/Modules/Wallet/WalletHomeView.swift
+++ b/FRW/Modules/Wallet/WalletHomeView.swift
@@ -375,7 +375,7 @@ struct WalletHomeView: View {
                     Text(
                         vm
                             .isHidden ? "****" :
-                            "\(CurrencyCache.cache.currencySymbol)\(vm.balance.formatCurrencyString(considerCustomCurrency: true))"
+                            "\(CurrencyCache.cache.currencySymbol)\(vm.balance.formatCurrencyString(digits: 2, considerCustomCurrency: true))"
                     )
                     .font(.Ukraine(size: 30, weight: .bold))
                     .foregroundStyle(Color.Theme.Text.black)
@@ -592,7 +592,7 @@ extension WalletHomeView {
                             Spacer()
 
                             Text(
-                                "\(vm.isHidden ? "****" : coin.balance.formatCurrencyString()) \(coin.token.symbol?.uppercased() ?? "?")"
+                                "\(vm.isHidden ? "****" : coin.balance.formatCurrencyString(digits: 2)) \(coin.token.symbol?.uppercased() ?? "?")"
                             )
                             .foregroundColor(.LL.Neutrals.text)
                             .font(.inter(size: 14, weight: .medium))
@@ -672,7 +672,7 @@ extension WalletHomeView {
                             Spacer()
 
                             Text(
-                                "\(vm.isHidden ? "****" : stakingManager.stakingCount.formatCurrencyString()) FLOW"
+                                "\(vm.isHidden ? "****" : stakingManager.stakingCount.formatCurrencyString(digits: 2)) FLOW"
                             )
                             .foregroundColor(.LL.Neutrals.text)
                             .font(.inter(size: 14, weight: .medium))

--- a/FRW/Modules/Wallet/WalletHomeView.swift
+++ b/FRW/Modules/Wallet/WalletHomeView.swift
@@ -375,7 +375,7 @@ struct WalletHomeView: View {
                     Text(
                         vm
                             .isHidden ? "****" :
-                            "\(CurrencyCache.cache.currencySymbol)\(vm.balance.formatCurrencyString(digits: 2, considerCustomCurrency: true))"
+                            "\(CurrencyCache.cache.currencySymbol)\(vm.balance.formatCurrencyStringForDisplay(digits: 2, considerCustomCurrency: true))"
                     )
                     .font(.Ukraine(size: 30, weight: .bold))
                     .foregroundStyle(Color.Theme.Text.black)
@@ -592,7 +592,7 @@ extension WalletHomeView {
                             Spacer()
 
                             Text(
-                                "\(vm.isHidden ? "****" : coin.balance.formatCurrencyString(digits: 2)) \(coin.token.symbol?.uppercased() ?? "?")"
+                                "\(vm.isHidden ? "****" : coin.balance.formatCurrencyStringForDisplay(digits: 2)) \(coin.token.symbol?.uppercased() ?? "?")"
                             )
                             .foregroundColor(.LL.Neutrals.text)
                             .font(.inter(size: 14, weight: .medium))
@@ -672,7 +672,7 @@ extension WalletHomeView {
                             Spacer()
 
                             Text(
-                                "\(vm.isHidden ? "****" : stakingManager.stakingCount.formatCurrencyString(digits: 2)) FLOW"
+                                "\(vm.isHidden ? "****" : stakingManager.stakingCount.formatCurrencyStringForDisplay(digits: 2)) FLOW"
                             )
                             .foregroundColor(.LL.Neutrals.text)
                             .font(.inter(size: 14, weight: .medium))

--- a/FRW/Modules/Wallet/WalletViewModel.swift
+++ b/FRW/Modules/Wallet/WalletViewModel.swift
@@ -34,7 +34,7 @@ extension WalletViewModel {
             guard last != 0 || token.symbol == "fusd" else {
                 return nil
             }
-            return "\(CurrencyCache.cache.currencySymbol)\(token.symbol == "fusd" ? CurrencyCache.cache.currentCurrencyRate.formatCurrencyString(digits: 4) : last.formatCurrencyString(digits: 4, considerCustomCurrency: true))"
+            return "\(CurrencyCache.cache.currencySymbol)\(token.symbol == "fusd" ? CurrencyCache.cache.currentCurrencyRate.formatCurrencyStringForDisplay(digits: 4) : last.formatCurrencyStringForDisplay(digits: 4, considerCustomCurrency: true))"
         }
 
         var changeString: String {
@@ -59,7 +59,7 @@ extension WalletViewModel {
         }
 
         var balanceAsCurrentCurrency: String {
-            (balance * last).formatCurrencyString(digits: 4, considerCustomCurrency: true)
+            (balance * last).formatCurrencyStringForDisplay(digits: 4, considerCustomCurrency: true)
         }
 
         static func mock() -> WalletViewModel.WalletCoinItemModel {

--- a/FRW/Services/Manager/BalanceProvider.swift
+++ b/FRW/Services/Manager/BalanceProvider.swift
@@ -42,7 +42,7 @@ class BalanceProvider: ObservableObject {
             else {
                 return
             }
-            balances[address] = model.value.formatCurrencyString()
+            balances[address] = model.value.formatCurrencyStringForDisplay()
         } catch {
             log.error("[Balance] fetch Flow flow balance :\(error)")
         }
@@ -59,7 +59,7 @@ class BalanceProvider: ObservableObject {
                     else {
                         return
                     }
-                    balances[address] = model.value.formatCurrencyString()
+                    balances[address] = model.value.formatCurrencyStringForDisplay()
                 }
             }
         } catch {
@@ -72,7 +72,7 @@ class BalanceProvider: ObservableObject {
             guard let evmAccount = EVMAccountManager.shared.accounts.first else { return }
             try await EVMAccountManager.shared.refreshBalance(address: evmAccount.address)
             let balance = EVMAccountManager.shared.balance
-            balances[evmAccount.showAddress] = balance.doubleValue.formatCurrencyString()
+            balances[evmAccount.showAddress] = balance.doubleValue.formatCurrencyStringForDisplay()
         } catch {
             log.error("[Balance] fetch EVM flow balance :\(error)")
         }

--- a/FRW/Services/Network/FRW/Model/Response/FlownsResponses.swift
+++ b/FRW/Services/Network/FRW/Model/Response/FlownsResponses.swift
@@ -72,7 +72,7 @@ struct InboxToken: Codable {
     }
 
     var amountText: String {
-        "\(amount.formatCurrencyString()) \(matchedCoin?.symbol?.uppercased() ?? "")"
+        "\(amount.formatCurrencyStringForDisplay()) \(matchedCoin?.symbol?.uppercased() ?? "")"
     }
 
     var marketPrice: Double {

--- a/FRW/UI/Extension/Double.swift
+++ b/FRW/UI/Extension/Double.swift
@@ -8,14 +8,17 @@
 import Foundation
 
 extension Double {
+    private var maxDigitsAllowed: Int { 4 }
+    
     static let currencyFormatter: NumberFormatter = {
         let f = NumberFormatter()
         f.maximumFractionDigits = 3
         f.minimumFractionDigits = 0
         return f
     }()
-
-    func formatCurrencyString(
+    
+    //TODO: SDK: this shouldn't be in the UI layer, should probably be somewhere in the SDK.
+    func formatCurrencyStringForTransaction(
         digits: Int = 2,
         roundingMode: NumberFormatter.RoundingMode = .down,
         considerCustomCurrency: Bool = false
@@ -24,7 +27,7 @@ extension Double {
             value: considerCustomCurrency ? self * CurrencyCache.cache
                 .currentCurrencyRate : self
         ).decimalValue
-
+        
         let f = NumberFormatter()
         f.maximumFractionDigits = digits
         f.minimumFractionDigits = digits
@@ -32,8 +35,78 @@ extension Double {
         return f.string(for: value) ?? "?"
     }
 
+    func formatCurrencyStringForDisplay(
+        digits: Int = 3,
+        roundingMode: NumberFormatter.RoundingMode = .halfUp,
+        considerCustomCurrency: Bool = false
+    ) -> String {
+        let value = considerCustomCurrency ? self * CurrencyCache.cache
+                .currentCurrencyRate : self
+
+        if abs(value) < 0.0001, value != 0 {
+            return value.formattedCurrency() ?? "?"
+        } else {
+            let formatter = NumberFormatter()
+            formatter.minimumFractionDigits = 0
+            formatter.maximumFractionDigits = min(digits, maxDigitsAllowed)
+            formatter.roundingMode = roundingMode
+            return formatter.string(from: NSNumber(value: value)) ?? "?"
+        }
+    }
+    
     var decimalValue: Decimal {
         // Deal with precision issue with swift decimal
         Decimal(string: String(self)) ?? Decimal(self)
+    }
+}
+
+extension Int {
+    func formattedToSubscriptNotion() -> String {
+        let subscriptNumbers: [Character] = ["₀", "₁", "₂", "₃", "₄", "₅", "₆", "₇", "₈", "₉"]
+        return String(self).compactMap { $0.wholeNumberValue }.map { String(subscriptNumbers[$0]) }.joined()
+    }
+}
+
+extension Double {
+    private func formattedCurrency() -> String? {
+        guard self != 0 else { return "0" }
+
+        let threshold = 0.0001
+
+        if abs(self) >= threshold {
+            let formatter = NumberFormatter()
+            formatter.minimumFractionDigits = 0
+            formatter.maximumFractionDigits = 8
+            formatter.roundingMode = .halfUp
+            return formatter.string(from: NSNumber(value: self))
+        }
+
+        let decimalString = String(format: "%.20f", abs(self)).split(separator: ".")[1]
+        var leadingZeros = 0
+
+        for char in decimalString {
+            guard char == "0" else { break }
+            leadingZeros += 1
+        }
+
+        var significantDigits = decimalString.dropFirst(leadingZeros)
+        let requiredDigits = 4
+
+        while significantDigits.count < requiredDigits {
+            significantDigits += "0"
+        }
+
+        var roundedNumber = Int(significantDigits.prefix(requiredDigits)) ?? 0
+        roundedNumber = (roundedNumber + 5) / 10
+
+        var roundedString = String(roundedNumber)
+
+        while roundedString.last == "0" {
+            roundedString.removeLast()
+        }
+
+        let subscriptZeros = leadingZeros.formattedToSubscriptNotion()
+
+        return "0.0\(subscriptZeros)\(roundedString)"
     }
 }

--- a/FRW/UI/Extension/Double.swift
+++ b/FRW/UI/Extension/Double.swift
@@ -16,7 +16,7 @@ extension Double {
     }()
 
     func formatCurrencyString(
-        digits: Int = 3,
+        digits: Int = 2,
         roundingMode: NumberFormatter.RoundingMode = .down,
         considerCustomCurrency: Bool = false
     ) -> String {


### PR DESCRIPTION
## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->
#907 

## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->

Use the old string formatting for sending transactions.  Only use new format for displaying strings.
Fixes sending small amounts like 0.000001 FLOW.

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [ ] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->



https://github.com/user-attachments/assets/ee214e9a-9315-4200-b3ba-121909bf5133


