### PR TITLE
fix: handle emptyMainAccount for revoked key during multi-restore

### DIFF
--- a/FRW/Modules/MultiRestore/ViewModel/RestoreMultiAccountViewModel.swift
+++ b/FRW/Modules/MultiRestore/ViewModel/RestoreMultiAccountViewModel.swift
@@ -66,6 +66,13 @@ class RestoreMultiAccountViewModel: ObservableObject {
                   await WalletManager.shared.cleanupRevokedAccount(userId: selectedUserId)
                   // Add the key again with new data
                   addKey(item: selectedUser)
+                } catch WalletError.emptyMainAccount {
+                  log.warning("[RestoreMultiAccountVM] Key revoked and no on-chain account found, cleaning up and adding new key")
+                  HUD.dismissLoading()
+                  // Key was revoked so keyIndexer returns no account for this public key
+                  // Clean up and create a new key
+                  await WalletManager.shared.cleanupRevokedAccount(userId: selectedUserId)
+                  addKey(item: selectedUser)
                 } catch {
                   log.error("switch account failed", context: error)
                   HUD.dismissLoading()


### PR DESCRIPTION
## Summary

- When a user's on-chain key is revoked, keyIndexer returns no account for the public key, causing `WalletError.emptyMainAccount` to be thrown
- `RestoreMultiAccountViewModel` did not catch this error, so it fell into the generic error handler and showed a confusing error message
- Added a catch for `emptyMainAccount` that follows the same recovery path as `noActiveKeys`: cleanup revoked account data and add a new key

## Root Cause

The validation flow in `WalletManager+KeyValidation`:
1. `validateKeyProvider` fetches account using the revoked key's public key
2. keyIndexer returns empty account list (revoked key is no longer associated)
3. Guard at line 114 fails → records as `providerWithoutAccount` (instead of detecting revoked state)
4. `buildFinalResult` Priority 1 returns `.providerWithoutAccount`
5. `restoreLogin` throws `WalletError.emptyMainAccount`
6. **Not caught** by RestoreMultiAccountViewModel → generic error

## Test plan

- [ ] Revoke a user's on-chain key, then try to restore/switch to that account
- [ ] Verify the app cleans up and triggers new key creation instead of showing an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)